### PR TITLE
files in images can be directories

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+    + files in images can be directories whose content is put in the image
+      target directory
     + Fix install instructions using new repository
     + Added duration of each executed tests in JUnit report
     + Stop properly the execution or creation if an error is found in the

--- a/src/lib/ANSTE/Comm/SlaveServer.pm
+++ b/src/lib/ANSTE/Comm/SlaveServer.pm
@@ -56,7 +56,7 @@ sub put	# (file, content)
     	close $FILE or die "Can't close: $!";
     	return 'OK';
     } else {
-	    return 'ERR';
+        return 'ERR';
     }
 }
 


### PR DESCRIPTION
- files in images can be directories whose content is put in the image
  target directory

However, the image target directory has the dir contents in the same directory so overwriting may happen. I didn't change much because my ignorance of this code. Two options came up to my mind:
1. Improve `put` to manage relative paths
2. Add new SOAP method `putRelative` to manage relative paths on the image.
